### PR TITLE
Remove aggregate and post transform from strategies

### DIFF
--- a/lib/mockingjay/strategies/perfect_tree_traversal.ex
+++ b/lib/mockingjay/strategies/perfect_tree_traversal.ex
@@ -127,7 +127,7 @@ defmodule Mockingjay.Strategies.PerfectTreeTraversal do
       root_thresholds: root_thresholds,
       values: values,
       condition: Mockingjay.Strategy.cond_to_fun(condition),
-      n_classes: n_weak_learner_classes
+      n_classes: n_classes
     ]
   end
 

--- a/lib/mockingjay/strategies/perfect_tree_traversal.ex
+++ b/lib/mockingjay/strategies/perfect_tree_traversal.ex
@@ -10,7 +10,7 @@ defmodule Mockingjay.Strategies.PerfectTreeTraversal do
 
   @impl true
   def init(data, opts \\ []) do
-    opts = Keyword.validate!(opts, [:forward, :aggregate, :post_transform, reorder_trees: true])
+    opts = Keyword.validate!(opts, reorder_trees: true)
     trees = DecisionTree.trees(data)
     condition = DecisionTree.condition(data)
     n_classes = DecisionTree.num_classes(data)
@@ -117,42 +117,18 @@ defmodule Mockingjay.Strategies.PerfectTreeTraversal do
 
     indices = 0..(nt - 1)//2 |> Enum.into([]) |> Nx.tensor(type: :s64)
 
-    forward_args =
-      if opts[:forward] do
-        [custom_forward: opts[:forward]]
-      else
-        [
-          indices: indices,
-          num_trees: num_trees,
-          max_tree_depth: max_tree_depth,
-          features: features,
-          thresholds: thresholds,
-          root_features: root_features,
-          root_thresholds: root_thresholds,
-          values: values,
-          condition: Mockingjay.Strategy.cond_to_fun(condition),
-          n_classes: n_weak_learner_classes
-        ]
-      end
-
-    post_transform_args =
-      if opts[:post_transform] do
-        [custom_post_transform: opts[:post_transform]]
-      else
-        [n_classes: n_classes]
-      end
-
-    aggregate_args =
-      if opts[:aggregate] do
-        [custom_aggregate: opts[:aggregate]]
-      else
-        [
-          n_classes: n_classes,
-          n_trees: num_trees
-        ]
-      end
-
-    {forward_args, aggregate_args, post_transform_args}
+    [
+      indices: indices,
+      num_trees: num_trees,
+      max_tree_depth: max_tree_depth,
+      features: features,
+      thresholds: thresholds,
+      root_features: root_features,
+      root_thresholds: root_thresholds,
+      values: values,
+      condition: Mockingjay.Strategy.cond_to_fun(condition),
+      n_classes: n_weak_learner_classes
+    ]
   end
 
   @impl true
@@ -172,22 +148,16 @@ defmodule Mockingjay.Strategies.PerfectTreeTraversal do
         :values
       ])
 
-    case opts[:custom_forward] do
-      value when value != nil ->
-        opts[:custom_forward].(x, opts)
-
-      _ ->
-        _forward(
-          x,
-          opts[:root_features],
-          opts[:root_thresholds],
-          opts[:features],
-          opts[:thresholds],
-          opts[:values],
-          opts[:indices],
-          Keyword.take(opts, [:num_trees, :condition, :n_classes])
-        )
-    end
+    _forward(
+      x,
+      opts[:root_features],
+      opts[:root_thresholds],
+      opts[:features],
+      opts[:thresholds],
+      opts[:values],
+      opts[:indices],
+      Keyword.take(opts, [:num_trees, :condition, :n_classes])
+    )
   end
 
   defnp _forward(
@@ -228,51 +198,6 @@ defmodule Mockingjay.Strategies.PerfectTreeTraversal do
     )
   end
 
-  @impl true
-  def aggregate(x, opts \\ []) do
-    opts = Keyword.validate!(opts, [:n_classes, :n_trees, :custom_aggregate])
-
-    if opts[:custom_aggregate] do
-      opts[:custom_aggregate].(x)
-    else
-      n_trees = opts[:n_trees]
-      n_classes = opts[:n_classes]
-
-      cond do
-        n_classes > 1 and n_trees > 1 ->
-          n_gbdt_classes = if n_classes > 2, do: n_classes, else: 1
-          n_trees_per_class = trunc(n_trees / n_gbdt_classes)
-
-          ensemble_aggregate(
-            x,
-            n_gbdt_classes,
-            n_trees_per_class
-          )
-
-        n_classes > 1 and n_trees == 1 ->
-          _aggregate(x)
-
-        true ->
-          raise "Unknown output type"
-      end
-    end
-  end
-
-  @impl true
-  def post_transform(x, opts \\ []) do
-    opts = Keyword.validate!(opts, [:custom_post_transform, :n_classes])
-
-    if opts[:custom_post_transform] do
-      opts[:custom_post_transform].(x)
-    else
-      transform =
-        Mockingjay.Strategy.infer_post_transform(opts[:n_classes])
-        |> Mockingjay.Strategy.post_transform_to_func()
-
-      transform.(x)
-    end
-  end
-
   defp make_tree_perfect(tree, current_depth, max_depth) do
     case tree do
       %Tree{left: nil, right: nil} ->
@@ -294,16 +219,5 @@ defmodule Mockingjay.Strategies.PerfectTreeTraversal do
           right: make_tree_perfect(right, current_depth + 1, max_depth)
         )
     end
-  end
-
-  deftransformp _aggregate(x) do
-    x
-    |> Nx.sum(axes: [1])
-  end
-
-  deftransformp ensemble_aggregate(x, n_gbdt_classes, n_trees_per_class) do
-    x
-    |> Nx.reshape({:auto, n_gbdt_classes, n_trees_per_class})
-    |> Nx.sum(axes: [2])
   end
 end

--- a/lib/mockingjay/strategies/tree_traversal.ex
+++ b/lib/mockingjay/strategies/tree_traversal.ex
@@ -125,7 +125,7 @@ defmodule Mockingjay.Strategies.TreeTraversal do
       thresholds: thresholds,
       values: values,
       condition: Mockingjay.Strategy.cond_to_fun(condition),
-      n_classes: n_weak_learner_classes
+      n_classes: n_classes
     ]
   end
 

--- a/lib/mockingjay/strategy.ex
+++ b/lib/mockingjay/strategy.ex
@@ -2,10 +2,8 @@ defmodule Mockingjay.Strategy do
   @moduledoc false
   @type t :: Nx.Container.t()
 
-  @callback init(data :: any(), opts :: Keyword.t()) :: {any(), any(), any()}
-  @callback forward(x :: Nx.Container.t(), opts :: Keyword.t()) :: Nx.Container.t()
-  @callback aggregate(x :: Nx.Container.t(), opts :: Keyword.t()) :: Nx.Container.t()
-  @callback post_transform(x :: Nx.Container.t(), opts :: Keyword.t()) :: Nx.Container.t()
+  @callback init(data :: any(), opts :: Keyword.t()) :: term()
+  @callback forward(x :: Nx.Container.t(), term()) :: Nx.Tensor.t()
 
   def cond_to_fun(condition)
       when condition in [:greater, :less, :greater_equal, :less_equal, :equal, :not_equal] do
@@ -22,29 +20,6 @@ defmodule Mockingjay.Strategy do
         ArgumentError,
         "Invalid condition: #{inspect(condition)} -- must be one of :greater, :less, :greater_equal, :less_equal, :equal, :not_equal -- or a custom function of arity 2"
       )
-
-  def infer_post_transform(n_classes) when is_integer(n_classes) do
-    cond do
-      n_classes <= 2 ->
-        :sigmoid
-
-      true ->
-        :softmax
-    end
-  end
-
-  def post_transform_to_func(post_transform)
-      when post_transform in [:softmax, :linear, :sigmoid, :log_softmax, :log_sigmoid] do
-    &apply(Axon.Activations, post_transform, [&1])
-  end
-
-  def post_transform_to_func(post_transform) when is_function(post_transform, 1) do
-    post_transform
-  end
-
-  def post_transform_to_func(post_transform),
-    do:
-      "Invalid post_transform: #{inspect(post_transform)} -- must be one of :none, :softmax, :sigmoid, :log_softmax, :log_sigmoig or :linear -- or a custom function of arity 1"
 
   def get_strategy(ensemble, opts \\ []) do
     opts = Keyword.validate!(opts, high: 10, low: 3)


### PR DESCRIPTION
To simplify, we require all strategies to return a tensor of shape {:auto, n_trees, n_classes}.

We are currently removing custom forward and custom aggregate,
but I don't believe we have a use case for them. If we want to add
them back, it should be easy to handle them in the compile function
(like we do for post_transform).

PS: Tests pass but I didn't run the notebook.